### PR TITLE
fixed file upload button text

### DIFF
--- a/src/pages/sender/ui/SenderPage/UploadInput.tsx
+++ b/src/pages/sender/ui/SenderPage/UploadInput.tsx
@@ -181,7 +181,7 @@ const UploadFile: React.FC<UploadFileProps> = ({ onFileChange }) => {
       onDragLeave={handleDragLeave}
     >
       <label className="btn-primary hover:opacity-70">
-        <span className="text-[20px]">Select files</span>
+        <span className="text-[20px] min-w-fit">Select files</span>
         <img src={uploadFileIcon} alt="uploadFile" />
         <Input
           type="file"


### PR DESCRIPTION
# Description

<!-- Describe the content of pull request -->
fixed bug - File upload button text appears in two lines and exceeds button boundaries in Mozilla

### Context

<!-- Give a brief explanation why this change is needed -->

## Demo

### Before

<!-- Add picture or video of the state before -->

### After

<!-- Add picture or video of the state after the change -->

## Links

<!-- Provide related links: to the ticket, to the design mockup -->
https://app.clickup.com/t/8696xyqgr
